### PR TITLE
track session

### DIFF
--- a/GoogleReporter.podspec
+++ b/GoogleReporter.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.social_media_url   = "http://twitter.com/ksmandersen"
 
   # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.ios.deployment_target = "10.0"
+  s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.12"
   s.tvos.deployment_target = "10.0"
 

--- a/GoogleReporter.swift
+++ b/GoogleReporter.swift
@@ -70,7 +70,19 @@ public class GoogleReporter {
         let data = parameters.combinedWith(["cd": name])
         send("screenView", parameters: data)
     }
-    
+
+    /// Tracks a session start to Google Analytics.
+    ///
+    /// - Parameter start: true indicate session started, false - session finished.
+    public func session(start: Bool) {
+        let queryArguments: [String: String] = [
+            "sc": start ? "start" : "end",
+            "dp": appName,
+        ]
+
+        send("", parameters: queryArguments)
+    }
+
     /// Tracks an event to Google Analytics.
     ///
     /// - Parameter category: The category of the event (ec).
@@ -109,8 +121,8 @@ public class GoogleReporter {
             print("You must set your tracker ID UA-XXXXX-XX with GoogleReporter.configure()")
             return
         }
-        
-        let queryArguments: [String: String] = [
+
+        var queryArguments: [String: String] = [
             "tid": trackerId,
             "aid": appIdentifier,
             "cid": uniqueUserIdentifier,
@@ -119,9 +131,11 @@ public class GoogleReporter {
             "ua": userAgent,
             "ul": userLanguage,
             "sr": screenResolution,
-            "v": "1",
-            "t": type
+            "v": "1"
         ]
+        if !type.isEmpty {
+            queryArguments.updateValue(type, forKey: "t")
+        }
         
         let arguments = queryArguments.combinedWith(parameters)
         guard let url = GoogleReporter.generateUrl(with: arguments) else {

--- a/GoogleReporter.xcodeproj/project.pbxproj
+++ b/GoogleReporter.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleReporter/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = co.kristian.GoogleReporter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -459,7 +459,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = GoogleReporter/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = co.kristian.GoogleReporter;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
+ added function to track session
+ deployment target for iOS set to iOS9 - i don't see any reasons why you need to use iOS 10 as target version if you don't use any iOS10 specific calls