### PR TITLE
Option to use IDFV

### DIFF
--- a/GoogleReporter.swift
+++ b/GoogleReporter.swift
@@ -46,9 +46,9 @@ public class GoogleReporter {
     /// Default is true.
     public var quietMode = true
 
-	///	Specifies if app should use IDFV (`UIDevice.current.identifierForVendor`), instead of `UUID().uuidString`
-	///	Default is false
-	public var useIDFV = false
+    ///	Specifies if app should use IDFV (`UIDevice.current.identifierForVendor`), instead of generating its own UUID.
+    ///	Default is false
+    public var usesVendorIdentifier = false
     
     private static let baseURL = URL(string: "https://www.google-analytics.com/")!
     private static let identifierKey = "co.kristian.GoogleReporter.uniqueUserIdentifier"
@@ -168,10 +168,9 @@ public class GoogleReporter {
     }
     
     private lazy var uniqueUserIdentifier: String = {
-		if self.useIDFV {
-			let identifier = UIDevice.current.identifierForVendor?.uuidString ?? "(unknown)"
-			return identifier
-		}
+        if let identifier = UIDevice.current.identifierForVendor?.uuidString, usesVendorIdentifier {
+            return identifier
+	}
 
         let defaults = UserDefaults.standard
         guard let identifier = defaults.string(forKey: GoogleReporter.identifierKey) else {

--- a/GoogleReporter.swift
+++ b/GoogleReporter.swift
@@ -45,6 +45,10 @@ public class GoogleReporter {
     /// Determines if stdout log from network requests are supressed.
     /// Default is true.
     public var quietMode = true
+
+	///	Specifies if app should use IDFV (`UIDevice.current.identifierForVendor`), instead of `UUID().uuidString`
+	///	Default is false
+	public var useIDFV = false
     
     private static let baseURL = URL(string: "https://www.google-analytics.com/")!
     private static let identifierKey = "co.kristian.GoogleReporter.uniqueUserIdentifier"
@@ -164,6 +168,11 @@ public class GoogleReporter {
     }
     
     private lazy var uniqueUserIdentifier: String = {
+		if self.useIDFV {
+			let identifier = UIDevice.current.identifierForVendor?.uuidString ?? "(unknown)"
+			return identifier
+		}
+
         let defaults = UserDefaults.standard
         guard let identifier = defaults.string(forKey: GoogleReporter.identifierKey) else {
             let identifier = UUID().uuidString


### PR DESCRIPTION
I’m not sure how is Apple looking at attempts to track app customers on your own, using `UUID()`

Thus I added option to use IDFV instead. OFF by default, so it fallbacks to behavior you already have.